### PR TITLE
Adding missing english lang string for capability mod/checklist:addinstance

### DIFF
--- a/lang/en/checklist.php
+++ b/lang/en/checklist.php
@@ -54,6 +54,7 @@ $string['checkeditemsdeleted'] = 'Checked items deleted';
 $string['checklist'] = 'checklist';
 $string['pluginadministration'] = 'Checklist administration';
 
+$string['checklist:addinstance'] = 'Add a new checklist';
 $string['checklist:edit'] = 'Create and edit checklists';
 $string['checklist:emailoncomplete'] = 'Receive completion emails';
 $string['checklist:preview'] = 'Preview a checklist';


### PR DESCRIPTION
Trivial patch to add in missing string for mod/checklist:addinstance capability.
