### PR TITLE
Added 'missing' code in mod/checklist/backup/moodle2/

### DIFF
--- a/backup/moodle2/restore_checklist_activity_task.class.php
+++ b/backup/moodle2/restore_checklist_activity_task.class.php
@@ -93,4 +93,44 @@ class restore_checklist_activity_task extends restore_activity_task {
             }
         }
     }
+
+
+    /**
+     * Added fix from https://tracker.moodle.org/browse/MDL-34172
+     */
+
+    /**
+     * Define the restore log rules that will be applied by the
+     * {@link restore_logs_processor} when restoring
+     * folder logs. It must return one array
+     * of {@link restore_log_rule} objects
+     */
+    static public function define_restore_log_rules() {
+        $rules = array();
+
+        $rules[] = new restore_log_rule('checklist', 'add', 'view.php?id={course_module}', '{folder}');
+        $rules[] = new restore_log_rule('checklist', 'edit', 'edit.php?id={course_module}', '{folder}');
+        $rules[] = new restore_log_rule('checklist', 'view', 'view.php?id={course_module}', '{folder}');
+
+        return $rules;
+    }
+
+    /**
+     * Define the restore log rules that will be applied
+     * by the {@link restore_logs_processor} when restoring
+     * course logs. It must return one array of
+     * {@link restore_log_rule} objects
+     *
+     * Note this rules are applied when restoring course logs
+     * by the restore final task, but are defined here at
+     * activity level. All them are rules not linked to any module instance (cmid = 0)
+     */
+    static public function define_restore_log_rules_for_course() {
+        $rules = array();
+
+        $rules[] = new restore_log_rule('checklist', 'view all', 'index.php?id={course}', null);
+
+        return $rules;
+    }
+
 }


### PR DESCRIPTION
...preventing restores from completing, as described in [MDL-34172](https://tracker.moodle.org/browse/MDL-34172).

Hi Davo. Am going through some course restore issues (as per [MDL-34172](https://tracker.moodle.org/browse/MDL-34172)) and [this comment](https://tracker.moodle.org/browse/MDL-34172?focusedCommentId=206139&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-206139) seems to define the problem and suggest a solution.  As the Checklist mod doesn't have the code suggested here (but allowing that I have seen no problems with restores specific to the Checklist mod) I have created this PR in the hope you find it useful.

~Paul.
