### PR TITLE
Improve checklist_print_overview()

### DIFF
--- a/lang/en/checklist.php
+++ b/lang/en/checklist.php
@@ -78,6 +78,7 @@ $string['completionpercentgroup'] = 'Require checked-off';
 $string['completionpercent'] = 'Percentage of items that should be checked-off:';
 
 $string['configchecklistautoupdate'] = 'Before allowing this you must make a few changes to the core Moodle code, please see mod/checklist/README.txt for details';
+$string['configshowupdateablemymoodle'] = 'If this is checked then only updatable Checklists will be shown from the \'My Moodle\' page';
 $string['configshowcompletemymoodle'] = 'If this is unchecked then completed Checklists will be hidden from the \'My Moodle\' page';
 $string['configshowmymoodle'] = 'If this is unchecked then Checklist activities (with progress bars) will no longer appear on the \'My Moodle\' page';
 
@@ -164,6 +165,7 @@ $string['savechecks'] = 'Save';
 
 $string['showcompletemymoodle'] = 'Show completed Checklists on \'My Moodle\' page';
 $string['showfulldetails'] = 'Show full details';
+$string['showupdateablemymoodle'] = 'Show only updatable Checklists on \'My Moodle\' page';
 $string['showmymoodle'] = 'Show Checklists on \'My Moodle\' page';
 $string['showprogressbars'] = 'Show progress bars';
 

--- a/lib.php
+++ b/lib.php
@@ -539,7 +539,9 @@ function checklist_print_overview($courses, &$htmlarray) {
     if (!isset($config->showcompletemymoodle)) {
         $config->showcompletemymoodle = 1;
     }
-
+    if (!isset($config->showupdateablemymoodle)) {
+        $config->showupdateablemymoodle = 1;
+    }
     if (empty($courses) || !is_array($courses) || count($courses) == 0) {
         return;
     }
@@ -552,13 +554,25 @@ function checklist_print_overview($courses, &$htmlarray) {
 
     foreach ($checklists as $checklist) {
         $show_all = true;
-        if ($checklist->teacheredit == CHECKLIST_MARKING_STUDENT) {
-            if ($CFG->version < 2011120100) {
-                $context = get_context_instance(CONTEXT_MODULE, $checklist->coursemodule);
-            } else {
-                $context = context_module::instance($checklist->coursemodule);
+        if ($CFG->version < 2011120100) {
+            $context = get_context_instance(CONTEXT_MODULE, $checklist->coursemodule);
+        } else {
+            $context = context_module::instance($checklist->coursemodule);
+        }
+        
+        // If the teacher is involved with updating the checklist.
+        if ($checklist->teacheredit == CHECKLIST_MARKING_TEACHER ||
+                $checklist->teacheredit == CHECKLIST_MARKING_BOTH) {
+            if ($config->showupdateablemymoodle) {
+                continue;
             }
-            $show_all = !has_capability('mod/checklist:updateown', $context);
+        // If only the student is responsible for updating the checklist.
+        } else if ($checklist->teacheredit == CHECKLIST_MARKING_STUDENT) {
+            if ($show_all = !has_capability('mod/checklist:updateown', $context)) {
+                if ($config->showupdateablemymoodle) {
+                    continue;
+                }
+            }
         }
 
         $progressbar = checklist_class::print_user_progressbar($checklist->id, $USER->id,

--- a/settings.php
+++ b/settings.php
@@ -30,4 +30,7 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configcheckbox('checklist/showcompletemymoodle',
                                                     get_string('showcompletemymoodle', 'mod_checklist'),
                                                     get_string('configshowcompletemymoodle', 'mod_checklist'), 1));
+    $settings->add(new admin_setting_configcheckbox('checklist/showupdateablemymoodle',
+                                                    get_string('showupdateablemymoodle', 'mod_checklist'),
+                                                    get_string('configshowupdateablemymoodle', 'mod_checklist'), 1));
 }


### PR DESCRIPTION
1. Add a new global setting - show only updateable checklists
2. If that setting is enabled then CHECKLIST_MARKING_TEACHER checklists
   will not be shown in 'my moodle' (check the type, then 'continue' the
   loop)
3. If that setting is enabled and the user does not have the capability
   'updateown', then skip that checklist ('continue' the loop)
4. 'CHECKLIST_MARKING_BOTH' checklists should also be hidden, as
   students cannot affect the progress bar, only teachers can update the
   progress bar.
5. Site Admin's will not see any checklist notices
