### PR TITLE
Provide a 'More help' link to MoodleDocs in activity chooser.

### DIFF
--- a/lang/en/checklist.php
+++ b/lang/en/checklist.php
@@ -145,6 +145,7 @@ $string['lockteachermarkswarning'] = 'Note: Once you have saved these marks, you
 
 $string['modulename'] = 'Checklist';
 $string['modulename_help'] = 'The checklist module allows a teacher to create a checklist / todo list / task list for their students to work through.';
+$string['modulename_link'] = 'mod/checklist/view';
 $string['modulenameplural'] = 'Checklists';
 
 $string['moveitemdown'] = 'Move item down';


### PR DESCRIPTION
Thanks!
That would provide such a link:
<img width="357" alt="activitychooserdocslink" src="https://user-images.githubusercontent.com/377279/60028662-08ea0900-96a0-11e9-8a46-ce24fbd68187.png">
