### PR TITLE
Apply same level of security to intro then core activities

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -848,7 +848,7 @@ class checklist_class {
         }
 
         // Gather some extra details needed in the output.
-        $intro = $this->formatted_intro();
+        $intro = format_module_intro('checklist', $this->checklist, $this->cm->id);
         $progress = null;
         if ($status->is_showprogressbar()) {
             $progress = $this->get_progress();
@@ -874,14 +874,6 @@ class checklist_class {
         }
 
         $this->output->checklist_items($this->items, $this->useritems, $this->groupings, $intro, $status, $progress, $student);
-    }
-
-    protected function formatted_intro() {
-        global $CFG;
-        $intro = file_rewrite_pluginfile_urls($this->checklist->intro, 'pluginfile.php', $this->context->id,
-                                              'mod_checklist', 'intro', null);
-        $opts = array('trusted' => $CFG->enabletrusttext);
-        return format_text($intro, $this->checklist->introformat, $opts);
     }
 
     protected function view_import_export() {


### PR DESCRIPTION
What is causing me to propose this small PR is that we were wondering why inserting an iframe in a Page activity intro worked while inserting an iframe in a Checklist activity intro did not. The reason is that the Checklist activity is applying different security constraints then other activities while formatting its intro.

My proposition is to align the plugin to core activities in relation to formatting the intro.