### PR TITLE
Student comments: Change style to inline

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -79,6 +79,7 @@ ol.checklist .teachercomment {
 }
 
 ol.checklist .studentcomment {
+    display: inline;
     color: black;
     background-color: #dbffb0;
     border: solid black 1px;


### PR DESCRIPTION
Hi @davosmith , just saw a small issue where the comments are not inline. That makes them look like the following examples:
![Screen Shot 2021-10-24 at 10 43 09 am](https://user-images.githubusercontent.com/37063983/138574698-da4b61e1-e8f9-484a-aa9a-e9cee49930b2.png)
![Screen Shot 2021-10-24 at 10 42 43 am](https://user-images.githubusercontent.com/37063983/138574699-7a6dc8b5-c977-4cfa-8398-7b16bd8d254b.png)

I've made a small PR to change this style