### PR TITLE
Properly display group selector in checklist activity section

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -1092,7 +1092,7 @@ class checklist_class {
             }
         }
 
-        groups_print_activity_menu($this->cm, $thisurl);
+        $out .= groups_print_activity_menu($this->cm, $thisurl, true);
         $activegroup = groups_get_activity_group($this->cm, true);
         if ($activegroup == 0) {
             if (groups_get_activity_groupmode($this->cm) == SEPARATEGROUPS) {


### PR DESCRIPTION
The `groups_print_activity_menu()` function has additional third parameter (`$return=false`), to control printing HTML output directly or just returning resulting string. Other parts of Moodle use this too, for example:

* mod/feedback/view.php
* mod/choice/report.php
* mod/choice/view.php

Without proposed change the group selector is printed at the top of the screen (regression).