### PR TITLE
Fix deprecation of implicit nullable parameter declarations.

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -30,8 +30,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.2'
+          - php: '8.3'
             moodle-branch: 'main'
+            database: 'mariadb'
+          - php: '8.3'
+            moodle-branch: 'MOODLE_404_STABLE'
             database: 'pgsql'
           - php: '8.2'
             moodle-branch: 'MOODLE_403_STABLE'

--- a/classes/local/checklist_check.php
+++ b/classes/local/checklist_check.php
@@ -63,7 +63,7 @@ class checklist_check extends data_object {
      * @param bool $fetch
      * @throws \coding_exception
      */
-    public function __construct(array $params = null, $fetch = true) {
+    public function __construct(?array $params = null, $fetch = true) {
         // Really ugly hack to stop travis complaining about $required_fields.
         $this->{'required_fields'} = $this->requiredfields;
         parent::__construct($params, $fetch);

--- a/classes/local/checklist_comment.php
+++ b/classes/local/checklist_comment.php
@@ -67,7 +67,7 @@ class checklist_comment extends data_object {
      * @param bool $fetch
      * @throws \coding_exception
      */
-    public function __construct(array $params = null, $fetch = true) {
+    public function __construct(?array $params = null, $fetch = true) {
         // Really ugly hack to stop travis complaining about $required_fields.
         $this->{'required_fields'} = $this->requiredfields;
         parent::__construct($params, $fetch);

--- a/classes/local/checklist_comment_student.php
+++ b/classes/local/checklist_comment_student.php
@@ -132,7 +132,7 @@ class checklist_comment_student extends persistent {
     public static function update_or_create_student_comment(
         int                       $checklistitemid,
         string                    $commenttext,
-        checklist_comment_student $existingcomment = null
+        ?checklist_comment_student $existingcomment = null
     ): bool {
         if (!$existingcomment) {
             $newcomment = new checklist_comment_student();

--- a/classes/local/checklist_item.php
+++ b/classes/local/checklist_item.php
@@ -117,7 +117,7 @@ class checklist_item extends data_object {
      * @param bool $fetch
      * @throws \coding_exception
      */
-    public function __construct(array $params = null, $fetch = true) {
+    public function __construct(?array $params = null, $fetch = true) {
         // Really ugly hack to stop travis complaining about $required_fields.
         $this->{'required_fields'} = $this->requiredfields;
         parent::__construct($params, $fetch);

--- a/tests/dates_test.php
+++ b/tests/dates_test.php
@@ -34,6 +34,7 @@ final class dates_test extends \advanced_testcase {
      * Set up steps
      */
     public function setUp(): void {
+        parent::setUp();
         $this->resetAfterTest();
     }
 

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -37,7 +37,7 @@ class mod_checklist_generator extends testing_module_generator {
      * @return stdClass
      * @throws coding_exception
      */
-    public function create_instance($record = null, array $options = null) {
+    public function create_instance($record = null, ?array $options = null) {
         $record = (object)(array)$record;
 
         $defaultsettings = [

--- a/tests/group_completion_email_test.php
+++ b/tests/group_completion_email_test.php
@@ -66,6 +66,7 @@ final class group_completion_email_test extends \advanced_testcase {
      */
     public function setUp(): void {
         global $DB;
+        parent::setUp();
 
         $this->resetAfterTest();
         unset_config('noemailever');
@@ -139,6 +140,7 @@ final class group_completion_email_test extends \advanced_testcase {
         $this->mailsink->close();
         unset($this->mailsink);
         previous_completions::override_time(null);
+        parent::tearDown();
     }
 
     /**

--- a/tests/privacy_provider_test.php
+++ b/tests/privacy_provider_test.php
@@ -46,6 +46,7 @@ final class privacy_provider_test extends \core_privacy\tests\provider_testcase 
      * {@inheritdoc}
      */
     protected function setUp(): void {
+        parent::setUp();
         $this->resetAfterTest();
 
         global $DB;

--- a/tests/student_comment_test.php
+++ b/tests/student_comment_test.php
@@ -58,6 +58,8 @@ final class student_comment_test extends \advanced_testcase {
      */
     public function setUp(): void {
         global $USER, $DB;
+        parent::setUp();
+
         $this->resetAfterTest();
         // Create test checklist with a couple items.
         $gen = self::getDataGenerator();


### PR DESCRIPTION
Those amendments let Moodle codechecker run through; they also check for Moodle 4.4 and PHP 8.3.