### PR TITLE
removes check for obsolete feature from "supports" callback.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -884,12 +884,6 @@ function checklist_supports($feature) {
         }
     }
 
-    if ((int)$CFG->branch < 28) {
-        if ($feature === FEATURE_GROUPMEMBERSONLY) {
-            return true;
-        }
-    }
-
     switch ($feature) {
         case FEATURE_GROUPS:
             return true;


### PR DESCRIPTION
this feature check can be safely removed without replacement at this point.

Moodle 2.8 was a long time ago, this plugin supports Moodle 4.1 and up. 

For reference, check the "2.8" section in the upgrade note for activity plugins, here: https://github.com/moodle/moodle/blob/main/mod/upgrade.txt

> === 2.8 ===
> * Constant FEATURE_GROUPMEMBERSONLY is deprecated. Modules should remove this
>   constant from their module_supports() API function.
> * $CFG->enablegroupmembersonly no longer exists.

this fixes #127 