### PR TITLE
CONTRIB-9548 Fix checklist display issues in iOS

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -71,7 +71,7 @@ class mod_checklist_renderer extends plugin_renderer_base {
 
         // Heading.
         $heading .= ':&nbsp;';
-        $out .= html_writer::div($heading, 'checklist_progress_heading');
+        $heading = html_writer::div($heading, 'checklist_progress_heading');
 
         // Progress bar.
         $progress = '';
@@ -80,9 +80,11 @@ class mod_checklist_renderer extends plugin_renderer_base {
         $progress = html_writer::div($progress, 'checklist_progress_outer');
         $progress .= html_writer::span('&nbsp;'.sprintf('%0d%%', $percentcomplete), 'checklist_progress_percent');
 
-        // Wrap in span + add clearer br.
-        $out .= html_writer::span($progress, '', ['id' => $spanid]);
-        $out .= html_writer::empty_tag('br', ['class' => 'clearer']);
+        $out .= html_writer::span(
+            $heading . $progress,
+            'checklist_progress_bar',
+            ['id' => $spanid]
+        );
 
         return $out;
     }

--- a/styles.css
+++ b/styles.css
@@ -188,9 +188,12 @@ ol.checklist li .itemteachername {
     background-color: #bf0000;
 }
 
+.checklist_progress_bar {
+    display: flex;
+}
+
 .checklist_progress_heading {
     display: block;
-    float: left;
     width: 150px;
 }
 
@@ -201,7 +204,6 @@ ol.checklist li .itemteachername {
     width: 300px;
     background-color: transparent;
     height: 15px;
-    float: left;
     overflow: hidden;
     position: relative;
     box-shadow: 2px 2px 3px #ccc;


### PR DESCRIPTION
This appears to be due to a Webkit bug caused by the particular combination of floats being used. Changing from float to flexbox resolves the issue.