### PR TITLE
Include section 0 when displaying course contents

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -390,7 +390,7 @@ class checklist_class {
 
         $mods = get_fast_modinfo($this->course);
 
-        $section = 1;
+        $section = 0;
         $nextpos = 1;
         $changes = false;
         reset($this->items);
@@ -430,10 +430,11 @@ class checklist_class {
                 continue;
             }
 
+            $sectionheadingmoduleid = ($section == 0) ? -1 : $section;
             $sectionheading = 0;
             while ($item = current($this->items)) {
                 // Search from current position.
-                if (($item->moduleid == $section) && ($item->itemoptional == CHECKLIST_OPTIONAL_HEADING)) {
+                if (($item->moduleid == $sectionheadingmoduleid) && ($item->itemoptional == CHECKLIST_OPTIONAL_HEADING)) {
                     $sectionheading = $item->id;
                     break;
                 }
@@ -443,7 +444,7 @@ class checklist_class {
             if (!$sectionheading) {
                 // Search again from the start.
                 foreach ($this->items as $item) {
-                    if (($item->moduleid == $section) && ($item->itemoptional == CHECKLIST_OPTIONAL_HEADING)) {
+                    if (($item->moduleid == $sectionheadingmoduleid) && ($item->itemoptional == CHECKLIST_OPTIONAL_HEADING)) {
                         $sectionheading = $item->id;
                         break;
                     }
@@ -462,7 +463,7 @@ class checklist_class {
                     0,
                     false,
                     false,
-                    $section,
+                    $sectionheadingmoduleid,
                     CHECKLIST_OPTIONAL_HEADING
                 );
                 reset($this->items);
@@ -1476,7 +1477,7 @@ class checklist_class {
                     if ($totalitems) {
                         $iparams['user'] = $auser->id;
                         $tickeditems = $DB->count_records_select('checklist_check', $sql, $iparams);
-                        $percentcomplete = ($tickeditems * 100.0) / $totalitems;
+                        $percentcomplete = ($tickeditems * 100) / $totalitems;
                     } else {
                         $percentcomplete = 0;
                         $tickeditems = 0;
@@ -1499,7 +1500,7 @@ class checklist_class {
                     $out .= '<div class="checklist_progress_inner" style="width:' . $percentcomplete . '%;">&nbsp;</div>';
                     $out .= '</div>';
                     $out .= '<div class="checklist_percentcomplete" style="float:left; width: 3em;">&nbsp;' .
-                        sprintf('%0d%%', round($percentcomplete)) . '</div>';
+                        sprintf('%0d%%', $percentcomplete) . '</div>';
                     $out .= '<div style="float:left;">&nbsp;(' . $tickeditems . '/' . $totalitems . ')</div>';
                     $out .= '<br style="clear:both;" />';
                 }


### PR DESCRIPTION
This plugin treats moduleid = 0 as a manual heading and has different rules. So section 0 is given an ID of -1 so it behaves as a course module item. This is fixing two bugs in one as the setting 'Show course modules in checklist' = 'Current section' would treat the heading incorrectly anyway.